### PR TITLE
remove NpSearch from Tools pages

### DIFF
--- a/tools/index.html
+++ b/tools/index.html
@@ -47,14 +47,6 @@ tools:
   status      : Beta. Used in Bioinforatics MSc course at QMUL.
   status_icon : fa-warning
 
-- name        : NeuroPeptide Search
-  img         : NpSearch.png
-  url         : https://github.com/wurmlab/NpSearch
-  code        : https://github.com/wurmlab/NpSearch
-  about       : NeuroPeptide Search uses the common features of neuropeptides to help identify novel neuropeptide precursors. Neuropeptide Search has already been successfully used to analyse the transcriptomes of ten different species, resulting in the discovery in numerous novel neuropeptides. Collaboration with <a href="http://www.sbcs.qmul.ac.uk/staff/mauriceelphick.html">M. Elphick</a>.
-  status      : Beta. Being prepped for release.
-  status_icon : fa-warning
-
 - name        : Transcript-genome consistency network
   img         : tgnet.jpg
   code        : https://github.com/ksanao/TGNet


### PR DESCRIPTION
Removes NpSearch from the tools pages as requested by @yannickwurm 