### PR TITLE
fix rel=canonical error

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ markdown: kramdown
 
 title: Ants, Genomes & Evolution @ Queen Mary University London
 
-url: '//wurmlab.com'
+url: 'https://wurmlab.com'
 production_url: 'https://wurmlab.com'
 
 permalink: "/news/:year-:month-:day-:title/"


### PR DESCRIPTION
`url:` variable in `_config.yml` was invalid, resulting in the following error:

![Screen Shot 2021-08-16 at 11 24 03 AM](https://user-images.githubusercontent.com/23062181/129611612-96ea5228-0b58-4686-9dd5-0d20ab8502d1.png)

This PR should fix that 