### PR TITLE
add site description for SEO and meta

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 markdown: kramdown
 
 title: Ants, Genomes & Evolution @ Queen Mary University London
-
+description: "We examine the evolutionary and genomic tradeoffs of social behavior in ants and other social animals. We develop data-rich approaches to understand the health of wild animals including pollinating bees. We produce bioinformatics tools to accelerate biological insight from large and complex molecular-genomic datasets."
 url: '//wurmlab.com'
 production_url: 'https://wurmlab.com'
 


### PR DESCRIPTION
added site description variable and content to `_config.yml`

This is the general site description which will be used as a fallback for any post or page that does not provide a description variable in the front matter.

custom descriptions can be provided per page or per post by adding the following to the page or post front matter:

```
---
description: "Add your custom description content here."
---
```