### PR TITLE
doctype provided by head.html include

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 {% include head.html %}
 <body data-spy="scroll" data-target=".subnav" data-offset="50">
   {% include navigation.html %}


### PR DESCRIPTION
removed `<!DOCTYPE html>` from layout file as it's now provided by `_includes/head.html`